### PR TITLE
add polyfill related config

### DIFF
--- a/configs/babel.config.js
+++ b/configs/babel.config.js
@@ -7,6 +7,11 @@ module.exports = {
         [
             "@babel/env",
             {
+                "useBuiltIns": "usage",
+                "corejs": {
+                    "version": 3,
+                    "proposals": true
+                },
                 // For async/await support
                 // https://babeljs.io/docs/en/babel-preset-env#targetsesmodules
                 targets: {

--- a/configs/babel.config.js
+++ b/configs/babel.config.js
@@ -9,8 +9,7 @@ module.exports = {
             {
                 "useBuiltIns": "usage",
                 "corejs": {
-                    "version": 3,
-                    "proposals": true
+                    "version": 3
                 },
                 // For async/await support
                 // https://babeljs.io/docs/en/babel-preset-env#targetsesmodules

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "pkg-to-readme": "^1.1.0",
     "textlint-tester": "^5.1.15"
   },
+  "peerDependencies": {
+    "core-js": "3"
+  },
   "prettier": {
     "singleQuote": false,
     "printWidth": 120,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/textlint/textlint-scripts",
   "devDependencies": {
+    "core-js": "3",
     "husky": "^3.1.0",
     "lint-staged": "^9.5.0",
     "prettier": "^1.8.1",


### PR DESCRIPTION
add polyfill related config. So that babel can compile some JS new feature(such as very useful instantance method `String.prototype.matchAll`) with polyfill.